### PR TITLE
Fix hook used

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -59,4 +59,4 @@ function etsy_metaboxes() {
 	) );
 
 }
-add_filter( 'cmb2_meta_boxes', 'etsy_metaboxes' );
+add_action( 'cmb2_init', 'etsy_metaboxes' );


### PR DESCRIPTION
RE: https://wordpress.org/support/topic/fatal-error-upon-activation-24/
Whenever using WP filters, the value passed in needs to be returned. Neither was happening.\
But that's irrelevant, since we just want to use the `cmb2_init` action anyway.

For those w/ knowledge of where these fields are used, please update to use the `cmb2_admin_init` if these CMB2 fields are not used on the frontend in any capacity. (I don't mean the `get_post_meta` calls, but like a front-end form or something)